### PR TITLE
Use php-cs-fixer in path

### DIFF
--- a/plugin/php-cs-fixer.vim
+++ b/plugin/php-cs-fixer.vim
@@ -11,7 +11,11 @@ let g:php_cs_fixer_enable_default_mapping = get(g:, 'php_cs_fixer_enable_default
 let g:php_cs_fixer_dry_run = get(g:, 'php_cs_fixer_dry_run', 0)
 let g:php_cs_fixer_verbose = get(g:, 'php_cs_fixer_verbose', 0)
 
-let g:php_cs_fixer_command = g:php_cs_fixer_php_path.' '.g:php_cs_fixer_path.' fix'
+if executable('php-cs-fixer')
+  let g:php_cs_fixer_command = 'php-cs-fixer fix'
+else
+  let g:php_cs_fixer_command = g:php_cs_fixer_php_path.' '.g:php_cs_fixer_path.' fix'
+end
 
 if exists('g:php_cs_fixer_config')
     let g:php_cs_fixer_command = g:php_cs_fixer_command.' --config='.g:php_cs_fixer_config
@@ -21,8 +25,10 @@ endif
 
 fun! PhpCsFixerFix(path, dry_run)
 
-    if !filereadable(expand(g:php_cs_fixer_path))
+    if !executable('php-cs-fixer')
+      if !filereadable(expand(g:php_cs_fixer_path))
         echoerr(g:php_cs_fixer_path.' is not found')
+      endif
     endif
 
     let command = g:php_cs_fixer_command.' '.a:path


### PR DESCRIPTION
Actually, it's impossible to use your plugin if php-cs-fixer is in the path (like a brew install).
Even with full path, i had some issue.

This PR should solve the issue (at least on my setup).

I use php54 / php-cs-fixer from homebrew.
