### PR TITLE
Fix broken --config-file for php-cs-fixer version 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ let g:php_cs_fixer_config = "default"                  " options: --config
 " If you use php-cs-fixer version 2.x
 let g:php_cs_fixer_rules = "@PSR2"          " options: --rules (default:@PSR2)
 "let g:php_cs_fixer_cache = ".php_cs.cache" " options: --cache-file
+"let g:php_cs_fixer_config_file = '.php_cs' " options: --config
 " End of php-cs-fixer version 2 config params
 
 let g:php_cs_fixer_php_path = "php"               " Path to PHP

--- a/plugin/php-cs-fixer.vim
+++ b/plugin/php-cs-fixer.vim
@@ -38,7 +38,11 @@ if g:php_cs_fixer_version == 1
 endif
 
 if exists('g:php_cs_fixer_config_file') && filereadable(g:php_cs_fixer_config_file)
-    let g:php_cs_fixer_command = g:php_cs_fixer_command . ' --config-file=' . g:php_cs_fixer_config_file
+    if g:php_cs_fixer_version == 1
+        let g:php_cs_fixer_command = g:php_cs_fixer_command . ' --config-file=' . g:php_cs_fixer_config_file
+    else
+        let g:php_cs_fixer_command = g:php_cs_fixer_command . ' --config=' . g:php_cs_fixer_config_file
+    endif
 endif
 
 if exists('g:php_cs_fixer_cache')


### PR DESCRIPTION
Specifying a value for `g:php_cs_fixer_config_file` causes the plugin to error out when using php-cs-fixer version 2.0. This is because php-cs-fixer dropped the `--config-file` option in version 2 and now uses `--config` for this purpose. 