### PR TITLE
Improve startup time with autoloading

### DIFF
--- a/autoload/php_cs_fixer.vim
+++ b/autoload/php_cs_fixer.vim
@@ -1,11 +1,6 @@
 "=============================================================================
-" File: php-cs-fixer.vim
+" File: autoload/php_cs_fixer.vim
 " Author: Stéphane PY
-
-if exists("g:vim_php_cs_fixer") || &cp
-    finish
-endif
-let g:vim_php_cs_fixer = 1
 
 " Global options definition."{{{
 let g:php_cs_fixer_path = get(g:, 'php_cs_fixer_path', '~/php-cs-fixer.phar')
@@ -27,9 +22,6 @@ if g:php_cs_fixer_version >= 2
 else
     let g:php_cs_fixer_level = get(g:, 'php_cs_fixer_level', 'symfony')
 endif
-let g:php_cs_fixer_enable_default_mapping = get(g:, 'php_cs_fixer_enable_default_mapping', '1')
-let g:php_cs_fixer_dry_run = get(g:, 'php_cs_fixer_dry_run', 0)
-let g:php_cs_fixer_verbose = get(g:, 'php_cs_fixer_verbose', 0)
 
 if g:php_cs_fixer_version == 1
 	if exists('g:php_cs_fixer_config')
@@ -50,7 +42,7 @@ if exists('g:php_cs_fixer_cache')
 endif
 "}}}
 
-fun! PhpCsFixerFix(path, dry_run)
+fun! php_cs_fixer#fix(path, dry_run)
 
     if !executable('php-cs-fixer')
       if !filereadable(expand(g:php_cs_fixer_path))
@@ -127,18 +119,3 @@ fun! PhpCsFixerFix(path, dry_run)
         endif
     endif
 endfun
-
-fun! PhpCsFixerFixDirectory()
-    call PhpCsFixerFix(expand('%:p:h'), g:php_cs_fixer_dry_run)
-endfun
-
-fun! PhpCsFixerFixFile()
-    call PhpCsFixerFix(expand('%:p'), g:php_cs_fixer_dry_run)
-endfun
-
-if(g:php_cs_fixer_enable_default_mapping == 1)
-    nnoremap <silent><leader>pcd :call PhpCsFixerFixDirectory()<CR>
-    nnoremap <silent><leader>pcf :call PhpCsFixerFixFile()<CR>
-endif
-
-" vim: foldmethod=marker

--- a/plugin/php_cs_fixer.vim
+++ b/plugin/php_cs_fixer.vim
@@ -1,0 +1,32 @@
+"=============================================================================
+" File: plugin/php_cs_fixer.vim
+" Author: Stéphane PY
+
+if exists("g:vim_php_cs_fixer") || &cp
+    finish
+endif
+let g:vim_php_cs_fixer = 1
+
+let g:php_cs_fixer_enable_default_mapping = get(g:, 'php_cs_fixer_enable_default_mapping', '1')
+let g:php_cs_fixer_dry_run = get(g:, 'php_cs_fixer_dry_run', 0)
+let g:php_cs_fixer_verbose = get(g:, 'php_cs_fixer_verbose', 0)
+
+" Backwards compatibility
+fun! PhpCsFixerFix(path, dry_run)
+    call php_cs_fixer#fix(a:path, a:dry_run)
+endfun
+
+fun! PhpCsFixerFixDirectory()
+    call php_cs_fixer#fix(expand('%:p:h'), g:php_cs_fixer_dry_run)
+endfun
+
+fun! PhpCsFixerFixFile()
+    call php_cs_fixer#fix(expand('%:p'), g:php_cs_fixer_dry_run)
+endfun
+
+if(g:php_cs_fixer_enable_default_mapping == 1)
+    nnoremap <silent><leader>pcd :call PhpCsFixerFixDirectory()<CR>
+    nnoremap <silent><leader>pcf :call PhpCsFixerFixFile()<CR>
+endif
+
+" vim: foldmethod=marker


### PR DESCRIPTION
While doing some profiling with `vim --startuptime`, I noticed that
php-cs-fixer.vim took the longest time to load. This is likely due to
the version check added in 54624e7.

I moved the all code that can be autoloaded to the autoload directory. I
also added a `PhpCsFixerFix` function, that simply calls the
`php_cs_fixer#fix` function, in case people were using `PhpCsFixerFix` in
their .vimrc.

I checked the startup time before and after this change:
- before: 191ms
- after: 105ms

I also renamed php-cs-fixer.vim to php_cs_fixer.vim, to be consistent
with the new autoload file. The autoload file can't have hyphens in its
name because it has to adhere to the function name which can only have
alphanumeric characters and '_' (see `:h E124` and `:h autoload`).