### PR TITLE
Add quotes around rules option to allow JSON rules

### DIFF
--- a/autoload/php_cs_fixer.vim
+++ b/autoload/php_cs_fixer.vim
@@ -71,7 +71,7 @@ fun! php_cs_fixer#fix(path, dry_run)
 
     if g:php_cs_fixer_version >= 2
         if exists('g:php_cs_fixer_rules') && g:php_cs_fixer_rules != '@PSR2'
-            let command = command.' --rules='.g:php_cs_fixer_rules
+            let command = command." --rules='".g:php_cs_fixer_rules."'"
         endif
     else
 		if exists('g:php_cs_fixer_level') && g:php_cs_fixer_level != 'all'


### PR DESCRIPTION
Hello,

php-cs-fixer allows to pass a JSON as rules, but it breaks without quotes (at least on OSX), so I added quote to be able to handle this case (example) : `php-cs-fixer --rules='{"@Symfony": true, "binary_operator_spaces": {"align_double_arrow":true, "align_equals": true}}' fix ...`