### PR TITLE
keep cursor position after file reload

### DIFF
--- a/autoload/php_cs_fixer.vim
+++ b/autoload/php_cs_fixer.vim
@@ -85,7 +85,9 @@ fun! php_cs_fixer#fix(path, dry_run)
     let s:output = system(command)
 
     if a:dry_run != 1
-      exec 'edit!'
+       let winstate = winsaveview()
+       exec 'edit!'
+       call winrestview(winstate)
     endif
 
     let fix_num = 0


### PR DESCRIPTION
Hi, here is little patch, which makes your cursor position to be at the same place where it was before calling to cs fixer.