### PR TITLE
fix: let  PhpCsFixer* find php_cs_fixer#fix [vim-php-cs-fixer]

### DIFF
--- a/autoload/php_cs_fixer.vim
+++ b/autoload/php_cs_fixer.vim
@@ -54,7 +54,7 @@ if exists('g:php_cs_fixer_cache')
 endif
 "}}}
 
-fun! php_cs_fixer#fix(path, dry_run)
+fun! fix(path, dry_run)
 
     if !executable('php-cs-fixer')
       if !filereadable(expand(g:php_cs_fixer_path))


### PR DESCRIPTION
When running this plugin as-is (environment details below), invoking `PhpCsFixerFixFile` or `PhpCsFixerFixDirectory` yields `Error detected while processing function PhpCsFixerFixFile:  E117: Unknown function: php_cs_fixer#fix`.  Other users seem to be [encountering](https://stackoverflow.com/a/31315171) this as well.

![image](https://user-images.githubusercontent.com/5384433/110065563-4c759100-7d24-11eb-8d21-3b94bd7440f2.png)

This PR fixes the issue.

Environment:
- Vim: 8.1
- php-cs-fixer: 2.18.2
