### PR TITLE
Add option for --allow-risky

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ let g:php_cs_fixer_config = "default"                  " options: --config
 let g:php_cs_fixer_rules = "@PSR2"          " options: --rules (default:@PSR2)
 "let g:php_cs_fixer_cache = ".php_cs.cache" " options: --cache-file
 "let g:php_cs_fixer_config_file = '.php_cs' " options: --config
+let g:php_cs_fixer_allow_risky = "yes"      " options: --allow-risky
 " End of php-cs-fixer version 2 config params
 
 let g:php_cs_fixer_php_path = "php"               " Path to PHP

--- a/autoload/php_cs_fixer.vim
+++ b/autoload/php_cs_fixer.vim
@@ -54,6 +54,10 @@ endif
 if exists('g:php_cs_fixer_cache')
     let g:php_cs_fixer_command = g:php_cs_fixer_command . ' --cache-file=' . g:php_cs_fixer_cache
 endif
+
+if exists('g:php_cs_fixer_allow_risky') && g:php_cs_fixer_version >= 1
+    let g:php_cs_fixer_command = g:php_cs_fixer_command . ' --allow-risky=' . g:php_cs_fixer_allow_risky
+endif
 "}}}
 
 fun! php_cs_fixer#Fix(path, dry_run)

--- a/autoload/php_cs_fixer.vim
+++ b/autoload/php_cs_fixer.vim
@@ -55,7 +55,7 @@ if exists('g:php_cs_fixer_cache')
     let g:php_cs_fixer_command = g:php_cs_fixer_command . ' --cache-file=' . g:php_cs_fixer_cache
 endif
 
-if exists('g:php_cs_fixer_allow_risky') && g:php_cs_fixer_version >= 1
+if exists('g:php_cs_fixer_allow_risky') && g:php_cs_fixer_version >= 2
     let g:php_cs_fixer_command = g:php_cs_fixer_command . ' --allow-risky=' . g:php_cs_fixer_allow_risky
 endif
 "}}}


### PR DESCRIPTION
defining `g:php_cs_fixer_allow_risky` now adds the
`--allow-risky=<value>` flag to the `php-cs-fixer` command